### PR TITLE
[PE-2879] chore(ci): upgrade GitHub Actions runtime

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,7 @@ jobs:
         run: cpack -C DebPack
         working-directory: _build
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.ossl-branch }} ${{ matrix.cmake-params }} ${{ matrix.libjade-build }} oqsprovider-x64
           path: _build/*.deb
@@ -249,7 +249,7 @@ jobs:
             dpkg -I oqs-provider-*.deb | grep -q "Architecture: arm64"
 
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqsprovider-aarch64
           path: build/*.deb

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -21,7 +21,7 @@ jobs:
       LIBOQS_BRANCH: "0.12.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
       - name: Full build
@@ -56,7 +56,7 @@ jobs:
       LIBOQS_BRANCH: "main"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
       - name: Full build
@@ -80,7 +80,7 @@ jobs:
         run: cpack -C DebPack
         working-directory: _build
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqsprovider-x86-x64-${{ matrix.libjade-build }}
           path: _build/lib/oqsprovider.so
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
 
@@ -178,7 +178,7 @@ jobs:
             dpkg -I oqs-provider-*.deb | grep -q "Architecture: arm64"
 
       - name: Retain .deb installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqsprovider-aarch64
           path: build/*.deb

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
           path: liboqs
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .localopenssl32
           key: ${{ runner.os }}-openssl32
@@ -54,7 +54,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             .localopenssl32
@@ -84,7 +84,7 @@ jobs:
             fi'
         working-directory: scripts
       - name: Retain oqsprovider.dylib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqs-provider-${{matrix.os}}-x64
           path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -28,7 +28,7 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
       - name: Checkout openssl
@@ -46,7 +46,7 @@ jobs:
           path: liboqs
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: .localopenssl32
           key: ${{ runner.os }}-openssl32
@@ -57,7 +57,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             .localopenssl32
@@ -87,7 +87,7 @@ jobs:
             fi'
         working-directory: scripts
       - name: Retain oqsprovider.dylib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqs-provider-${{matrix.os}}-x64
           path: _build/lib/oqsprovider.dylib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,12 @@ jobs:
             && echo "provider_ref=$provider_ref" >> "$GITHUB_ENV" \
             || echo "provider_ref=main" >> "$GITHUB_ENV"
       - name: Checkout oqs-provider on requested ref if it exists; otherwise, fall back to main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.provider_ref }}
       # This is designed to be triggered automatically from liboqs CI, so don't bother validating the liboqs ref.
       - name: Checkout liboqs at requested ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: open-quantum-safe/liboqs
           path: liboqs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
           packages: perl git ninja gcc-core cmake make python3 python3-devel python3-setuptools python3-exceptiongroup
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: c:\cygwin\opt\openssl32
           key: ${{ runner.os }}-cygwinopenssl32
@@ -64,7 +64,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             c:\cygwin\opt\openssl32
@@ -97,7 +97,7 @@ jobs:
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-cygwin
           path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Restore OpenSSL32 cache
         id: cache-openssl32
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: c:\openssl32
           key: ${{ runner.os }}-msvcopenssl32
@@ -193,7 +193,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             c:\openssl32
@@ -207,7 +207,7 @@ jobs:
         run: |
           ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
           path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
@@ -234,7 +234,7 @@ jobs:
     steps:
         - name: Restore native OpenSSL32 cache
           id: cache-openssl32n
-          uses: actions/cache@v4
+          uses: actions/cache@v6
           with:
             path: c:\openssl32n
             key: ${{ runner.os }}-msvcopenssl32n
@@ -299,7 +299,7 @@ jobs:
         - name: Save OpenSSL
           id: cache-openssl-save
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v3
+          uses: actions/cache/save@v6
           with:
             path: |
               c:\openssl32n
@@ -312,7 +312,7 @@ jobs:
           run: |
             ctest -V --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: ${{matrix.os}} ${{matrix.platform.arch}} oqs-provider-msvc
             path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -32,11 +32,11 @@ jobs:
       MAKE_PARAMS: -j 4
     steps:
       - name: Checkout provider
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
       - name: Checkout openssl
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: openssl/openssl
@@ -44,7 +44,7 @@ jobs:
           # TODO: Revert ref tag once openssl master doesn't crash any more
           ref: openssl-3.4.0
       - name: checkout liboqs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
@@ -56,7 +56,7 @@ jobs:
           packages: perl git ninja gcc-core cmake make python3 python3-devel python3-setuptools python3-exceptiongroup
       - name: Retrieve OpenSSL32 from cache
         id: cache-openssl32
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: c:\cygwin\opt\openssl32
           key: ${{ runner.os }}-cygwinopenssl32
@@ -69,7 +69,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             c:\cygwin\opt\openssl32
@@ -102,7 +102,7 @@ jobs:
         run: bash -c "echo $PATH && PATH=/opt/openssl32/bin:/usr/bin ctest -V"
         working-directory: _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqs-provider-cygwin
           path: D:/a/oqs-provider/oqs-provider/_build/bin/oqsprovider.dll
@@ -127,22 +127,22 @@ jobs:
     steps:
       - name: Restore OpenSSL32 cache
         id: cache-openssl32
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: c:\openssl32
           key: ${{ runner.os }}-msvcopenssl32
       - name: Checkout provider
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 0.8.0
       - name: Checkout OpenSSL master
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: openssl/openssl
           path: openssl
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: open-quantum-safe/liboqs
@@ -202,7 +202,7 @@ jobs:
       - name: Save OpenSSL
         id: cache-openssl-save
         if: steps.cache-openssl32.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v6
         with:
           path: |
             c:\openssl32
@@ -216,7 +216,7 @@ jobs:
         run: |
           ctest -V --test-dir _build
       - name: Retain oqsprovider.dll
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oqs-provider-msvc
           path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll
@@ -244,22 +244,22 @@ jobs:
     steps:
         - name: Restore native OpenSSL32 cache
           id: cache-openssl32n
-          uses: actions/cache@v3
+          uses: actions/cache@v6
           with:
             path: c:\openssl32n
             key: ${{ runner.os }}-msvcopenssl32n
         - name: Checkout provider
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             ref: 0.8.0
         - name: Checkout OpenSSL master
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             set-safe-directory: true
             repository: openssl/openssl
             path: openssl
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
           with:
             set-safe-directory: true
             repository: open-quantum-safe/liboqs
@@ -312,7 +312,7 @@ jobs:
         - name: Save OpenSSL
           id: cache-openssl-save
           if: steps.cache-openssl32n.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v3
+          uses: actions/cache/save@v6
           with:
             path: |
               c:\openssl32n
@@ -325,7 +325,7 @@ jobs:
           run: |
             ctest --test-dir _build -C ${{ matrix.type }}
         - name: Retain oqsprovider.dll
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: oqs-provider-msvc
             path: D:/a/oqs-provider/oqs-provider/_build/lib/oqsprovider.dll


### PR DESCRIPTION
Updates workflow actions to released, Node 24-compatible major versions.